### PR TITLE
feat: add --timewindow and --force options for data collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Available CLI options:
 - `--latitude`: Latitude of the solar panels.
 - `--longitude`: Longitude of the solar panels.
 - `--api-key`: API key for the SolarEdge API.
-- `--timewindow`: Optional time window in minutes used for solar information.
+- `--timewindow`: Optional time window in minutes used for the technical-data lookback window.
 - `--force`: Collect data even outside the daylight window.
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # solaredge-influxdb
 Uploading data from Solar Edge API towards Influxdb on a regular interval of 5 minutes to prevent rate limiting
+
+## Usage
+
+Run the application with:
+
+```bash
+python -m solaredge_influxdb
+```
+
+Available CLI options:
+
+- `--config-path`: Path to the configuration file.
+- `--latitude`: Latitude of the solar panels.
+- `--longitude`: Longitude of the solar panels.
+- `--api-key`: API key for the SolarEdge API.
+- `--timewindow`: Optional time window in minutes used for solar information.
+- `--force`: Collect data even outside the daylight window.
+
+Examples:
+
+```bash
+python -m solaredge_influxdb --config-path ./solaredge_influxdb/config.toml --timewindow 15
+python -m solaredge_influxdb --force
+```
+
+By default, the application skips data collection outside the configured daylight window. Use `--force` to collect data even after sundown.

--- a/solaredge_influxdb/__main__.py
+++ b/solaredge_influxdb/__main__.py
@@ -29,6 +29,11 @@ parser.add_argument(
     type=int,
     help="Optional time window (in minutes) used for solar information",
 )
+parser.add_argument(
+    "--force",
+    action="store_true",
+    help="Collect data even outside the daylight window",
+)
 
 logger.info("Starting application; to get SolarEdge data into InfluxDB")
 

--- a/solaredge_influxdb/app.py
+++ b/solaredge_influxdb/app.py
@@ -34,14 +34,18 @@ def app(
         raise RuntimeError("Application requires sunset and sunrise times to prevent unnecessary API calls") from e
     InfluxClient = InfluxDBClient(config_path)
 
-    should_collect = force or sunrise - timedelta(minutes=additional_time_window) < current_time < sunset + timedelta(
+    within_daylight_window = sunrise - timedelta(minutes=additional_time_window) < current_time < sunset + timedelta(
         minutes=additional_time_window
     )
+    should_collect = force or within_daylight_window
 
     if should_collect:
-        if force:
-            logger.info("Force mode enabled, collecting data outside the daylight window")
-        logger.debug("The Sun is shining bright, let's collect some data!")
+        if force and not within_daylight_window:
+            logger.info("Force mode enabled, bypassing daylight-window checks to collect data")
+        if within_daylight_window:
+            logger.debug("The Sun is shining bright, let's collect some data!")
+        else:
+            logger.debug("Collecting data because force mode is enabled")
         EquipmentClient = Equipment(api_key)
         current_time = current_time.astimezone(_timezone)
         for inverter in EquipmentClient.inverters:

--- a/solaredge_influxdb/app.py
+++ b/solaredge_influxdb/app.py
@@ -17,6 +17,7 @@ def app(
     additional_time_window: int = 60,
     timezone_str: str = "Europe/Amsterdam",
     timewindow: int = 15,  # Time window in minutes for collecting technical data, default is 15 minutes
+    force: bool = False,
 ):
     observer = Observer(latitude=latitude, longitude=longitude)
     current_time = datetime.now(timezone.utc)
@@ -33,7 +34,13 @@ def app(
         raise RuntimeError("Application requires sunset and sunrise times to prevent unnecessary API calls") from e
     InfluxClient = InfluxDBClient(config_path)
 
-    if sunrise - timedelta(minutes=additional_time_window) < current_time < sunset + timedelta(minutes=additional_time_window):
+    should_collect = force or sunrise - timedelta(minutes=additional_time_window) < current_time < sunset + timedelta(
+        minutes=additional_time_window
+    )
+
+    if should_collect:
+        if force:
+            logger.info("Force mode enabled, collecting data outside the daylight window")
         logger.debug("The Sun is shining bright, let's collect some data!")
         EquipmentClient = Equipment(api_key)
         current_time = current_time.astimezone(_timezone)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+from solaredge_influxdb.app import app
+
+
+def _build_telemetry():
+    return SimpleNamespace(
+        operationMode="operating",
+        inverterMode="production",
+        date=datetime(2026, 5, 6, 22, 0, 0),
+        totalEnergy=2500,
+        totalActivePower=1200,
+        vL1To2=230,
+        vL2To3=231,
+        vL3To1=229,
+        dcVoltage=400,
+    )
+
+
+@patch("solaredge_influxdb.app.datetime")
+@patch("solaredge_influxdb.app.InfluxDBClient")
+@patch("solaredge_influxdb.app.Equipment")
+@patch("solaredge_influxdb.app.Sun")
+def test_app_skips_collection_after_sundown(mock_sun, mock_equipment, mock_influxdb_client, mock_datetime):
+    current_time = datetime(2026, 5, 6, 22, 0, 0, tzinfo=timezone.utc)
+    sunrise = datetime(2026, 5, 6, 5, 0, 0, tzinfo=timezone.utc)
+    sunset = datetime(2026, 5, 6, 18, 0, 0, tzinfo=timezone.utc)
+    mock_datetime.now.return_value = current_time
+    mock_sun.return_value.get_sunrise_time.return_value = sunrise
+    mock_sun.return_value.get_sunset_time.return_value = sunset
+
+    app(api_key="api-key")
+
+    mock_equipment.assert_not_called()
+    mock_influxdb_client.return_value.write.assert_not_called()
+
+
+@patch("solaredge_influxdb.app.datetime")
+@patch("solaredge_influxdb.app.InfluxDBClient")
+@patch("solaredge_influxdb.app.Equipment")
+@patch("solaredge_influxdb.app.Sun")
+def test_app_collects_after_sundown_when_forced(mock_sun, mock_equipment, mock_influxdb_client, mock_datetime):
+    current_time = datetime(2026, 5, 6, 22, 0, 0, tzinfo=timezone.utc)
+    sunrise = datetime(2026, 5, 6, 5, 0, 0, tzinfo=timezone.utc)
+    sunset = datetime(2026, 5, 6, 18, 0, 0, tzinfo=timezone.utc)
+    telemetry = _build_telemetry()
+    equipment_client = Mock()
+    equipment_client.inverters = [SimpleNamespace(serialNumber="INV-1", model="SE5000")]
+    equipment_client.get_technical_data.return_value = SimpleNamespace(telemetries=[telemetry])
+    influx_client = mock_influxdb_client.return_value
+    influx_client.convert_to_point.side_effect = ["energy-point", "power-point", "voltage-point"]
+
+    mock_datetime.now.return_value = current_time
+    mock_sun.return_value.get_sunrise_time.return_value = sunrise
+    mock_sun.return_value.get_sunset_time.return_value = sunset
+    mock_equipment.return_value = equipment_client
+
+    app(api_key="api-key", force=True)
+
+    mock_equipment.assert_called_once_with("api-key")
+    equipment_client.get_technical_data.assert_called_once()
+    assert influx_client.write.call_args_list == [
+        call("energy-point", "energy"),
+        call("power-point", "energy_flow"),
+        call("voltage-point", "voltage_current"),
+    ]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,17 +19,19 @@ def _build_telemetry():
     )
 
 
+@patch("solaredge_influxdb.app.get_sunset")
+@patch("solaredge_influxdb.app.get_sunrise")
 @patch("solaredge_influxdb.app.datetime")
 @patch("solaredge_influxdb.app.InfluxDBClient")
 @patch("solaredge_influxdb.app.Equipment")
-@patch("solaredge_influxdb.app.Sun")
-def test_app_skips_collection_after_sundown(mock_sun, mock_equipment, mock_influxdb_client, mock_datetime):
-    current_time = datetime(2026, 5, 6, 22, 0, 0, tzinfo=timezone.utc)
-    sunrise = datetime(2026, 5, 6, 5, 0, 0, tzinfo=timezone.utc)
-    sunset = datetime(2026, 5, 6, 18, 0, 0, tzinfo=timezone.utc)
+def test_app_skips_collection_after_sundown(mock_equipment, mock_influxdb_client, mock_datetime, mock_get_sunrise, mock_get_sunset):
+    # 20:00 UTC = 22:00 CEST, which is still May 6 in Amsterdam and after sunset
+    current_time = datetime(2026, 5, 6, 20, 0, 0, tzinfo=timezone.utc)
+    sunrise = datetime(2026, 5, 6, 3, 30, 0, tzinfo=timezone.utc)
+    sunset = datetime(2026, 5, 6, 17, 0, 0, tzinfo=timezone.utc)
     mock_datetime.now.return_value = current_time
-    mock_sun.return_value.get_sunrise_time.return_value = sunrise
-    mock_sun.return_value.get_sunset_time.return_value = sunset
+    mock_get_sunrise.return_value = sunrise
+    mock_get_sunset.return_value = sunset
 
     app(api_key="api-key")
 
@@ -37,14 +39,16 @@ def test_app_skips_collection_after_sundown(mock_sun, mock_equipment, mock_influ
     mock_influxdb_client.return_value.write.assert_not_called()
 
 
+@patch("solaredge_influxdb.app.get_sunset")
+@patch("solaredge_influxdb.app.get_sunrise")
 @patch("solaredge_influxdb.app.datetime")
 @patch("solaredge_influxdb.app.InfluxDBClient")
 @patch("solaredge_influxdb.app.Equipment")
-@patch("solaredge_influxdb.app.Sun")
-def test_app_collects_after_sundown_when_forced(mock_sun, mock_equipment, mock_influxdb_client, mock_datetime):
-    current_time = datetime(2026, 5, 6, 22, 0, 0, tzinfo=timezone.utc)
-    sunrise = datetime(2026, 5, 6, 5, 0, 0, tzinfo=timezone.utc)
-    sunset = datetime(2026, 5, 6, 18, 0, 0, tzinfo=timezone.utc)
+def test_app_collects_after_sundown_when_forced(mock_equipment, mock_influxdb_client, mock_datetime, mock_get_sunrise, mock_get_sunset):
+    # 20:00 UTC = 22:00 CEST, which is still May 6 in Amsterdam and after sunset
+    current_time = datetime(2026, 5, 6, 20, 0, 0, tzinfo=timezone.utc)
+    sunrise = datetime(2026, 5, 6, 3, 30, 0, tzinfo=timezone.utc)
+    sunset = datetime(2026, 5, 6, 17, 0, 0, tzinfo=timezone.utc)
     telemetry = _build_telemetry()
     equipment_client = Mock()
     equipment_client.inverters = [SimpleNamespace(serialNumber="INV-1", model="SE5000")]
@@ -53,8 +57,8 @@ def test_app_collects_after_sundown_when_forced(mock_sun, mock_equipment, mock_i
     influx_client.convert_to_point.side_effect = ["energy-point", "power-point", "voltage-point"]
 
     mock_datetime.now.return_value = current_time
-    mock_sun.return_value.get_sunrise_time.return_value = sunrise
-    mock_sun.return_value.get_sunset_time.return_value = sunset
+    mock_get_sunrise.return_value = sunrise
+    mock_get_sunset.return_value = sunset
     mock_equipment.return_value = equipment_client
 
     app(api_key="api-key", force=True)


### PR DESCRIPTION

This pull request adds a new "force" mode to allow data collection outside the daylight window, updates the CLI and documentation to support this feature, and introduces tests to verify the new behavior. The most important changes are grouped below.

**Feature: Force Data Collection Outside Daylight Window**
* Added a `force` parameter to the `app` function in `app.py`, allowing data collection even when it's outside the sunrise/sunset window. The main logic now checks this parameter before skipping collection. [[1]](diffhunk://#diff-e982b0e4e795dd1f7cef1f61badd1ad397c4123f6a0299fb22e9e7748334c9ecR20) [[2]](diffhunk://#diff-e982b0e4e795dd1f7cef1f61badd1ad397c4123f6a0299fb22e9e7748334c9ecL36-R43)

**CLI and Documentation Updates**
* Added a `--force` CLI flag in `__main__.py` to expose the new feature to users.
* Updated `README.md` with usage instructions and examples for the new `--force` flag.

**Testing**
* Added two tests in `test_app.py`: one to ensure data collection is skipped after sundown by default, and another to ensure data is collected when the `force` flag is used.