### PR TITLE
feat: enhance write method to support string and Point payloads logging

### DIFF
--- a/solaredge_influxdb/influxdb/client.py
+++ b/solaredge_influxdb/influxdb/client.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import influxdb_client
 from influxdb_client.client.write_api import SYNCHRONOUS
 from typing import Union, List, Tuple, Optional
+from loguru import logger
 
 
 class InfluxDBClient:
@@ -9,8 +10,14 @@ class InfluxDBClient:
         self.client = influxdb_client.InfluxDBClient.from_config_file(path)
         self.write_api = self.client.write_api(write_options=SYNCHRONOUS)
 
-    def write(self, data: str, bucket: str) -> None:
+    def write(self, data: Union[str, influxdb_client.Point], bucket: str) -> None:
         """Write data to InfluxDB"""
+        if isinstance(data, str):
+            record_payload = data
+        else:
+            record_payload = data.to_line_protocol()
+
+        logger.debug("Writing record to InfluxDB bucket='{}': {}", bucket, record_payload)
         self.write_api.write(bucket=bucket, record=data)
 
     def convert_to_point(

--- a/solaredge_influxdb/influxdb/client.py
+++ b/solaredge_influxdb/influxdb/client.py
@@ -13,11 +13,14 @@ class InfluxDBClient:
     def write(self, data: Union[str, influxdb_client.Point], bucket: str) -> None:
         """Write data to InfluxDB"""
         if isinstance(data, str):
-            record_payload = data
+            logger.debug("Writing record to InfluxDB bucket='{}': {}", bucket, data)
         else:
-            record_payload = data.to_line_protocol()
+            logger.opt(lazy=True).debug(
+                "Writing record to InfluxDB bucket='{}': {}",
+                bucket,
+                lambda: data.to_line_protocol(),
+            )
 
-        logger.debug("Writing record to InfluxDB bucket='{}': {}", bucket, record_payload)
         self.write_api.write(bucket=bucket, record=data)
 
     def convert_to_point(

--- a/solaredge_influxdb/influxdb/client.py
+++ b/solaredge_influxdb/influxdb/client.py
@@ -17,7 +17,7 @@ class InfluxDBClient:
         else:
             logger.opt(lazy=True).debug(
                 "Writing record to InfluxDB bucket='{}': {}",
-                bucket,
+                lambda: bucket,
                 lambda: data.to_line_protocol(),
             )
 

--- a/tests/influxdb/test_client.py
+++ b/tests/influxdb/test_client.py
@@ -1,4 +1,6 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, create_autospec
+
+import influxdb_client
 
 from solaredge_influxdb.influxdb.client import InfluxDBClient
 
@@ -6,17 +8,20 @@ from solaredge_influxdb.influxdb.client import InfluxDBClient
 def test_write_logs_serialized_record_for_point_payload():
     influx_client = InfluxDBClient.__new__(InfluxDBClient)
     influx_client.write_api = Mock()
-    point = Mock()
+    point = create_autospec(influxdb_client.Point, instance=True)
     point.to_line_protocol.return_value = "solar,serial_number=INV-1 total_energy=2.5 1746568800000"
 
-    with patch("solaredge_influxdb.influxdb.client.logger.debug") as mock_debug:
+    mock_lazy_logger = Mock()
+    with patch("solaredge_influxdb.influxdb.client.logger.opt", return_value=mock_lazy_logger) as mock_opt:
         influx_client.write(point, "energy")
 
-    mock_debug.assert_called_once_with(
-        "Writing record to InfluxDB bucket='{}': {}",
-        "energy",
-        "solar,serial_number=INV-1 total_energy=2.5 1746568800000",
-    )
+    mock_opt.assert_called_once_with(lazy=True)
+    mock_lazy_logger.debug.assert_called_once()
+    call_args = mock_lazy_logger.debug.call_args[0]
+    assert call_args[0] == "Writing record to InfluxDB bucket='{}': {}"
+    assert call_args[1]() == "energy"
+    assert call_args[2]() == "solar,serial_number=INV-1 total_energy=2.5 1746568800000"
+    point.to_line_protocol.assert_called_once()
     influx_client.write_api.write.assert_called_once_with(bucket="energy", record=point)
 
 

--- a/tests/influxdb/test_client.py
+++ b/tests/influxdb/test_client.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock, patch
+
+from solaredge_influxdb.influxdb.client import InfluxDBClient
+
+
+def test_write_logs_serialized_record_for_point_payload():
+    influx_client = InfluxDBClient.__new__(InfluxDBClient)
+    influx_client.write_api = Mock()
+    point = Mock()
+    point.to_line_protocol.return_value = "solar,serial_number=INV-1 total_energy=2.5 1746568800000"
+
+    with patch("solaredge_influxdb.influxdb.client.logger.debug") as mock_debug:
+        influx_client.write(point, "energy")
+
+    mock_debug.assert_called_once_with(
+        "Writing record to InfluxDB bucket='{}': {}",
+        "energy",
+        "solar,serial_number=INV-1 total_energy=2.5 1746568800000",
+    )
+    influx_client.write_api.write.assert_called_once_with(bucket="energy", record=point)
+
+
+def test_write_logs_string_payload():
+    influx_client = InfluxDBClient.__new__(InfluxDBClient)
+    influx_client.write_api = Mock()
+    payload = "solar,serial_number=INV-1 total_energy=2.5 1746568800000"
+
+    with patch("solaredge_influxdb.influxdb.client.logger.debug") as mock_debug:
+        influx_client.write(payload, "energy")
+
+    mock_debug.assert_called_once_with(
+        "Writing record to InfluxDB bucket='{}': {}",
+        "energy",
+        payload,
+    )
+    influx_client.write_api.write.assert_called_once_with(bucket="energy", record=payload)


### PR DESCRIPTION
This pull request adds improved logging to the `InfluxDBClient.write` method and introduces new tests to verify the logging behavior. The main focus is on ensuring that both string and `Point` payloads are properly logged before being written to InfluxDB.

**Logging Enhancements:**

* Updated the `InfluxDBClient.write` method in `client.py` to log the serialized record payload (whether a string or a `Point` object) before writing to InfluxDB, using `loguru.logger.debug`.

**Testing Improvements:**

* Added two unit tests in `test_client.py` to verify that the correct log message is emitted for both `Point` and string payloads, and that the write API is called with the correct parameters.…logging